### PR TITLE
Refactor internals without changing API (almost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Inspired by:
   - Piotr Solnica's [virtus](https://github.com/solnic/virtus)
   - Everything [Michel Martens](https://github.com/soveran)
 
-Portrayal is a minimalist gem (~130 loc, no dependencies) for building struct-like classes. It provides a small yet powerful step up from plain ruby with its one and only `keyword` method.
+Portrayal is a minimalist gem (~110 loc, no dependencies) for building struct-like classes. It provides a small yet powerful step up from plain ruby with its one and only `keyword` method.
 
 ```ruby
 class Person < MySuperClass
@@ -336,9 +336,9 @@ else
 end # => "matched"
 ```
 
-### Schema
+### Introspection
 
-Every class that has at least one keyword defined in it automatically receives a class method called `portrayal`. This method is a schema of your object with some additional helpers.
+Every class that extends Portrayal receives a method called `portrayal`. This method is a schema of your object with some additional helpers.
 
 #### `portrayal.keywords`
 
@@ -445,10 +445,10 @@ end
 
 #### No Reinventing The Wheel
 
-Portrayal leans on Ruby to take care of enforcing required keyword arguments, and setting keyword argument defaults. It actually generates standard ruby keyword arguments for you behind the scenes. You can even see the code by checking `YourClass.portrayal.definition_of_initialize`.
+Portrayal leans on Ruby to take care of enforcing required keyword arguments, and setting keyword argument defaults. It actually generates standard ruby keyword arguments for you behind the scenes. You can see the code by checking `YourClass.portrayal.render_initialize`.
 
 ```irb
-Address.portrayal.definition_of_initialize
+Address.portrayal.render_initialize
 => "def initialize(street:,city:,postcode:,country: self.class.portrayal.call_default(:country)); @street = street; @city = city; @postcode = postcode; @country = country end"
 ```
 

--- a/lib/portrayal.rb
+++ b/lib/portrayal.rb
@@ -2,32 +2,21 @@ require 'portrayal/version'
 require 'portrayal/schema'
 
 module Portrayal
-  NULL = :_portrayal_value_not_set
+  attr_reader :portrayal
+  def self.extended(c); c.instance_variable_set(:@portrayal, Schema.new) end
+  def inherited(c); c.instance_variable_set(:@portrayal, portrayal.dup) end
 
-  def keyword(name, default: NULL, define: nil, &block)
-    unless respond_to?(:portrayal)
-      class << self
-        attr_reader :portrayal
-        def inherited(base)
-          base.instance_variable_set('@portrayal', portrayal.dup)
-        end
-      end
-
-      @portrayal = Schema.new
-      class_eval(Schema::DEFINITION_OF_OBJECT_ENHANCEMENTS)
-    end
-
+  def keyword(name, default: Schema::NULL, define: nil, &block)
+    include Portrayal::Methods if portrayal.empty?
     attr_accessor name
     protected "#{name}="
-
     portrayal.add_keyword(name, default)
-    class_eval(portrayal.definition_of_initialize)
+    class_eval(portrayal.render_initialize)
 
     if block_given?
-      kw_class = Class.new(superclass) { extend Portrayal }
-      const_set(define || portrayal.camelize(name), kw_class).class_eval(&block)
+      nested = Class.new(superclass) { extend ::Portrayal }
+      const_set(define || portrayal.camelize(name), nested).class_eval(&block)
     end
-
     name
   end
 end

--- a/lib/portrayal/default.rb
+++ b/lib/portrayal/default.rb
@@ -1,5 +1,6 @@
 class Portrayal::Default
-  protected attr_reader :value
+  attr_reader :value
+  protected :value
 
   def initialize(value)
     @value = value

--- a/lib/portrayal/default.rb
+++ b/lib/portrayal/default.rb
@@ -1,13 +1,11 @@
-module Portrayal
-  class Default
-    attr_reader :value
+class Portrayal::Default
+  protected attr_reader :value
 
-    def initialize(value)
-      @value = value
-      @callable = value.is_a?(Proc) && !value.lambda?
-    end
-
-    def call?; @callable end
-    def initialize_dup(src); super; @value = src.value.dup end
+  def initialize(value)
+    @value = value
+    @callable = value.is_a?(Proc) && !value.lambda?
   end
+
+  def get(obj); @callable ? obj.instance_exec(&value) : value end
+  def initialize_dup(src); @value = src.value.dup; super end
 end

--- a/lib/portrayal/methods.rb
+++ b/lib/portrayal/methods.rb
@@ -1,0 +1,36 @@
+module Portrayal::Methods
+  def eql?(other); self.class == other.class && self == other end
+  def hash; [self.class, self.class.portrayal.attributes(self)].hash end
+  def deconstruct; self.class.portrayal.attributes(self).values end
+
+  def deconstruct_keys(keys)
+    return self.class.portrayal.attributes(self) unless Array === keys
+    keys &= self.class.portrayal.keywords
+    Hash[keys.map { |k| [k, send(k)] }]
+  end
+
+  def ==(other)
+    return super unless other.class.is_a?(Portrayal)
+    self.class.portrayal.attributes(self) ==
+      self.class.portrayal.attributes(other)
+  end
+
+  def freeze
+    self.class.portrayal.attributes(self).values.each(&:freeze)
+    super
+  end
+
+  def initialize_dup(source)
+    self.class.portrayal.attributes(source).each do |key, value|
+      instance_variable_set("@#{key}", value.dup)
+    end
+    super
+  end
+
+  def initialize_clone(source)
+    self.class.portrayal.attributes(source).each do |key, value|
+      instance_variable_set("@#{key}", value.clone)
+    end
+    super
+  end
+end

--- a/lib/portrayal/schema.rb
+++ b/lib/portrayal/schema.rb
@@ -1,79 +1,35 @@
 require 'portrayal/default'
+require 'portrayal/methods'
 
-module Portrayal
-  class Schema
-    attr_reader :schema
+class Portrayal::Schema
+  attr_reader :schema
+  NULL = Object.new.freeze
 
-    DEFINITION_OF_OBJECT_ENHANCEMENTS = <<~RUBY.freeze
-      def eql?(other); self.class == other.class && self == other end
-      def hash; [self.class, self.class.portrayal.attributes(self)].hash end
-      def deconstruct; self.class.portrayal.attributes(self).values end
+  def initialize;         @schema = {}                                      end
+  def keywords;           @schema.keys                                      end
+  def [](name);           @schema[name]                                     end
+  def empty?;             @schema.empty?                                    end
+  def attributes(object); Hash[keywords.map { |k| [k, object.send(k)] }]    end
+  def camelize(string);   string.to_s.gsub(/(?:^|_+)([^_])/) { $1.upcase }  end
+  def initialize_dup(o);  @schema = o.schema.transform_values(&:dup); super end
 
-      def deconstruct_keys(keys)
-        keys ||= self.class.portrayal.keywords
-        keys &= self.class.portrayal.keywords
-        Hash[keys.map { |k| [k, send(k)] }]
-      end
+  def add_keyword(name, default)
+    name = name.to_sym
+    @schema.delete(name) # Forcing keyword to be added at the end of the hash.
+    @schema[name] = default.equal?(NULL) ? nil : Portrayal::Default.new(default)
+  end
 
-      def ==(other)
-        return super unless other.class.is_a?(Portrayal)
+  def render_initialize
+    args, assigns = '', ''
 
-        self.class.portrayal.attributes(self) ==
-          self.class.portrayal.attributes(other)
-      end
-
-      def freeze
-        self.class.portrayal.attributes(self).values.each(&:freeze)
-        super
-      end
-
-      def initialize_dup(source)
-        self.class.portrayal.attributes(source).each do |key, value|
-          instance_variable_set("@\#{key}", value.dup)
-        end
-        super
-      end
-
-      def initialize_clone(source)
-        self.class.portrayal.attributes(source).each do |key, value|
-          instance_variable_set("@\#{key}", value.clone)
-        end
-        super
-      end
-    RUBY
-
-    def initialize; @schema = {}  end
-    def keywords;   @schema.keys  end
-    def [](name);   @schema[name] end
-
-    def attributes(object)
-      Hash[object.class.portrayal.keywords.map { |k| [k, object.send(k)] }]
+    @schema.each do |key, default|
+      args    << "#{key}:#{default && " self.class.portrayal[:#{key}]"}, "
+      assigns << "@#{key} = #{key}.is_a?(::Portrayal::Default) ? " \
+                 "#{key}.get(self) : #{key}; "
     end
 
-    def camelize(string); string.to_s.gsub(/(?:^|_+)([^_])/) { $1.upcase } end
-
-    def add_keyword(name, default)
-      name = name.to_sym
-      @schema.delete(name) # Forcing keyword to be added at the end of the hash.
-      @schema[name] = default.equal?(NULL) ? nil : Default.new(default)
-    end
-
-    def initialize_dup(other)
-      super; @schema = other.schema.transform_values(&:dup)
-    end
-
-    def definition_of_initialize
-      init_args = @schema.map { |name, default|
-        "#{name}:#{default && " self.class.portrayal[:#{name}]"}"
-      }.join(', ')
-
-      init_assigns = @schema.keys.map { |name|
-        "@#{name} = #{name}.is_a?(::Portrayal::Default) ? " \
-          "(#{name}.call? ? instance_exec(&#{name}.value) : #{name}.value) : " \
-          "#{name}"
-      }.join('; ')
-
-      "def initialize(#{init_args}); #{init_assigns} end"
-    end
+    args.chomp!(', ')
+    assigns.chomp!('; ')
+    "def initialize(#{args}); #{assigns} end"
   end
 end


### PR DESCRIPTION
Arguably there's one API change — enhancement methods are now included as a module rather than being `class_eval'ed`. However, that shouldn't affect most things.

Overview of changes:

* Improve convenience internally
* Move enhancements into a proper module
* Add .portrayal upon `extend Portrayal` (not first keyword)
* Reorganize specs for consistency
* Reduce the lines of code count